### PR TITLE
GF-2193 Omit .circleci when publishing to the WordPress.org SVN repo

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -1,3 +1,4 @@
+.circleci
 .git
 .gitignore
 .gitattributes


### PR DESCRIPTION
Ensures the .circleci folder does not get uploaded to the WP.org plugin directory.

### How to test
Code review.

### Notes
Once this has merged to develop, develop can be merged to master and the updated README can be pushed to the WP.org repo. No changelog or version bump is required.